### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3 teststairs.py"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Super Mario Stairs
 
+[![Run on Repl.it](https://repl.it/badge/github/upperlinecode/mario-python-functions)](https://repl.it/github/upperlinecode/mario-python-functions)
+
 Super Mario Bros. (1985) is among the most iconic videogames of all time.
 
 Even though the game has 32 levels, many speedrunners can beat the entire thing in under five minutes.


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@jolson615/mario-python-functions).